### PR TITLE
(Fix #59) Raise a warning when finding invalid nodes 

### DIFF
--- a/lira/parsers/rst.py
+++ b/lira/parsers/rst.py
@@ -1,3 +1,5 @@
+import logging
+
 from docutils.frontend import OptionParser
 from docutils.nodes import Element
 from docutils.parsers.rst import Directive, Parser, directives
@@ -5,6 +7,9 @@ from docutils.utils import new_document
 
 from lira.parsers import BaseParser
 from lira.parsers import nodes as booknodes
+
+# TODO: make a global logging config
+logger = logging.getLogger(__name__)
 
 
 class DirectiveNode(Element):
@@ -129,16 +134,18 @@ class RSTParser(BaseParser):
             tag = child.tagname
             if tag == "section":
                 nodes.append(self._parse_section(child))
-            if tag == "directive":
+            elif tag == "directive":
                 directive_name = child.attributes.get("name")
                 if directive_name == "test-block":
                     nodes.append(self._parse_test(child))
                 elif directive_name == "code-block":
                     nodes.append(self._parse_code(child))
-            if tag in self.terminal_nodes:
+            elif tag in self.terminal_nodes:
                 nodes.append(self.terminal_nodes[tag](child.astext()))
             elif tag in self.container_nodes:
                 nodes.append(self.container_nodes[tag](*self._parse_content(child)))
+            else:
+                logger.warning("Node with tag %(tag)s is not supported", {"tag": tag})
         return nodes
 
     def _parse_code(self, node):

--- a/tests/test_rst_parser.py
+++ b/tests/test_rst_parser.py
@@ -1,4 +1,6 @@
+import logging
 from pathlib import Path
+from unittest.mock import patch
 
 from lira.parsers.rst import RSTParser
 
@@ -92,3 +94,13 @@ class TestRSTParser:
         assert testblock.options["description"] == "Write another comment"
         assert testblock.options["help"] == "Just write another comment :)"
         assert testblock.options["validator"] == "lira.validators.CommentValidator"
+
+    def test_parse_invalid_node(self):
+        logger = logging.getLogger("lira.parsers.rst")
+        with patch.object(logger, "warning") as mocked_logger:
+            parser = RSTParser(content=":title:`hello`\n", source="invalid_test")
+            parser.parse_content()
+            tag = "title_reference"
+            mocked_logger.assert_called_once_with(
+                "Node with tag %(tag)s is not supported", {"tag": tag}
+            )


### PR DESCRIPTION
Fix #59 

- Config warning logger
- Added a warning condition when tag doesn't match with handled tags. 
- Added a unit test checking the logged warning 

