### PR TITLE
Fix documentation typo(s)

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -28,6 +28,7 @@ or a local path to the directory of the book
 (it can be a relative path to the config file).
 
 .. code-block:: yaml
+
    books:
       # A dotted path to a module
       - lira.books.intro

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -22,7 +22,7 @@ Create a virtual environment:
 
 .. code-block:: bash
 
-   python -m venv ven
+   python -m venv venv
    source venv/bin/activate
 
 Install the project locally with:


### PR DESCRIPTION
[1] add 'n' to the end of 'python -m venv ven' (docs/development.rst)
[2] add space on line 31 (docs/config.rst)